### PR TITLE
fix: support Pi 0.84.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pi Black is an unofficial Pi package that routes Anthropic OAuth requests throug
 
 ## Install
 
-Pi Black is pinned to Pi 0.84.1 and fails closed on other Pi versions.
+Pi Black is pinned to Pi 0.84.2 and fails closed on other Pi versions.
 
 ```sh
 pi install git:github.com/paoloanzn/pi-black

--- a/src/claude-code-protocol.ts
+++ b/src/claude-code-protocol.ts
@@ -9,7 +9,7 @@ import type {
 	StreamOptions,
 } from "@earendil-works/pi-ai";
 
-export const SUPPORTED_PI_VERSION = "0.84.1";
+export const SUPPORTED_PI_VERSION = "0.84.2";
 export const CLAUDE_CODE_VERSION = "2.1.224";
 export const CLAUDE_CODE_ENTRYPOINT = "sdk-cli";
 


### PR DESCRIPTION
## Problem

Pi shipped `0.84.2`, but the guard in `src/claude-code-protocol.ts` still pins `0.84.1`. Because the check is an exact `!==`, the extension fails closed on load for anyone on current Pi:

```
Error: Failed to load extension ".../pi-black.ts": Failed to load extension: Pi Black supports Pi 0.84.1; running Pi is 0.84.2
Hint: Start without extensions using "pi -ne".
```

## Change

- `SUPPORTED_PI_VERSION` `0.84.1` -> `0.84.2`
- README pin note bumped to match

`0.84.1` -> `0.84.2` is a patch release. Verified the extension loads clean against `@earendil-works/pi-coding-agent@0.84.2` locally (no more guard throw; provider registers).

## Scope

Kept the diff to the guard + README so it stays lockfile-clean. Left the `package.json` dep pins (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`) and the release-tag install snippets in the README for your release step, since bumping those touches the lockfile and a new tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Pi Black to support Pi version 0.84.2.
  * Updated the documented pinned Pi version to 0.84.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->