### PR TITLE
Support Pi 0.84.2 packages

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pi-compatibility:
+    name: Pi ${{ matrix.pi-version }} package compatibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        pi-version:
+          - '0.84.1'
+          - '0.84.2'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: Install package dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Pi ${{ matrix.pi-version }}
+        run: |
+          npm install \
+            --no-save \
+            --package-lock=false \
+            --ignore-scripts \
+            --legacy-peer-deps \
+            @earendil-works/pi-ai@${{ matrix.pi-version }} \
+            @earendil-works/pi-coding-agent@${{ matrix.pi-version }}
+
+      - name: Check package
+        env:
+          EXPECTED_PI_VERSION: ${{ matrix.pi-version }}
+        run: npm run check
+
   verify:
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ Pi Black is an unofficial Pi package that routes Anthropic OAuth requests throug
 
 ## Install
 
-Pi Black is pinned to Pi 0.84.1 and fails closed on other Pi versions.
+Pi Black has three independently versioned compatibility surfaces:
+
+| Component | Compatible version |
+| --- | --- |
+| Pi package | Pi 0.84.1 and 0.84.2 |
+| Standalone `pi-black` binary | Based on Pi 0.84.1 |
+| Claude Code protocol | 2.1.224 |
+
+The Pi package fails closed on versions other than 0.84.1 and 0.84.2. Each new Pi version must be explicitly revalidated and added to the runtime allowlist; the package peer dependencies are `"*"` because Pi supplies its core packages at runtime.
 
 ```sh
 pi install git:github.com/paoloanzn/pi-black

--- a/extensions/pi-black.ts
+++ b/extensions/pi-black.ts
@@ -1,15 +1,16 @@
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import { type ExtensionAPI, VERSION } from "@earendil-works/pi-coding-agent";
 import { wrapAnthropicProvider } from "../src/anthropic-provider.ts";
+import { discoverClaudeCodeIdentity } from "../src/claude-code-protocol.ts";
 import {
-	discoverClaudeCodeIdentity,
-	SUPPORTED_PI_VERSION,
-} from "../src/claude-code-protocol.ts";
+	isSupportedPiVersion,
+	SUPPORTED_PI_VERSIONS,
+} from "../src/compatibility.ts";
 
 export default function piBlack(pi: ExtensionAPI): void {
-	if (VERSION !== SUPPORTED_PI_VERSION) {
+	if (!isSupportedPiVersion(VERSION)) {
 		throw new Error(
-			`Pi Black supports Pi ${SUPPORTED_PI_VERSION}; running Pi is ${VERSION}`,
+			`Pi Black supports Pi ${SUPPORTED_PI_VERSIONS.join(", ")}; running Pi is ${VERSION}`,
 		);
 	}
 	const anthropic = builtinProviders().find(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.84.1",
-        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@earendil-works/pi-ai": "0.84.2",
+        "@earendil-works/pi-coding-agent": "0.84.2",
         "@types/node": "24.12.4",
         "typescript": "5.9.3",
         "vitest": "4.1.9"
@@ -19,8 +19,8 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "0.84.1",
-        "@earendil-works/pi-coding-agent": "0.84.1"
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -514,22 +514,21 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -541,18 +540,18 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
-      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.1",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-client": "^0.84.1",
-        "@earendil-works/pi-protocol": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1043,13 +1042,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1060,21 +1059,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1086,20 +1084,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.1"
+        "@earendil-works/pi-protocol": "^0.84.2"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1110,8 +1108,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1119,8 +1117,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1346,27 +1344,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1388,16 +1365,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
@@ -2184,14 +2151,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2527,30 +2491,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2589,27 +2533,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2618,16 +2541,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3967,14 +3880,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -4493,18 +4403,10 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "test": "vitest --run"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "0.84.1",
-    "@earendil-works/pi-coding-agent": "0.84.1"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.84.1",
-    "@earendil-works/pi-coding-agent": "0.84.1",
+    "@earendil-works/pi-ai": "0.84.2",
+    "@earendil-works/pi-coding-agent": "0.84.2",
     "@types/node": "24.12.4",
     "typescript": "5.9.3",
     "vitest": "4.1.9"

--- a/src/claude-code-protocol.ts
+++ b/src/claude-code-protocol.ts
@@ -9,7 +9,6 @@ import type {
 	StreamOptions,
 } from "@earendil-works/pi-ai";
 
-export const SUPPORTED_PI_VERSION = "0.84.1";
 export const CLAUDE_CODE_VERSION = "2.1.224";
 export const CLAUDE_CODE_ENTRYPOINT = "sdk-cli";
 

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -1,0 +1,9 @@
+export const SUPPORTED_PI_VERSIONS = ["0.84.1", "0.84.2"] as const;
+
+export type SupportedPiVersion = (typeof SUPPORTED_PI_VERSIONS)[number];
+
+export function isSupportedPiVersion(
+	version: string,
+): version is SupportedPiVersion {
+	return (SUPPORTED_PI_VERSIONS as readonly string[]).includes(version);
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,30 @@
+import type { Provider } from "@earendil-works/pi-ai";
+import {
+	type ExtensionAPI,
+	VERSION,
+} from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import piBlack from "../extensions/pi-black.ts";
+import {
+	isSupportedPiVersion,
+	SUPPORTED_PI_VERSIONS,
+} from "../src/compatibility.ts";
+
+describe("Pi Black extension", () => {
+	it("registers the wrapped Anthropic provider with the installed Pi version", () => {
+		expect(isSupportedPiVersion(VERSION)).toBe(true);
+		if (process.env.EXPECTED_PI_VERSION)
+			expect(VERSION).toBe(process.env.EXPECTED_PI_VERSION);
+		const registerProvider = vi.fn<(provider: Provider) => void>();
+
+		piBlack({ registerProvider } as unknown as ExtensionAPI);
+
+		expect(registerProvider).toHaveBeenCalledOnce();
+		expect(registerProvider.mock.calls[0][0].id).toBe("anthropic");
+	});
+
+	it("fails closed for Pi versions that have not been validated", () => {
+		expect(SUPPORTED_PI_VERSIONS).toEqual(["0.84.1", "0.84.2"]);
+		expect(isSupportedPiVersion("0.84.3")).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #1.

## Summary

- use `"*"` for Pi core peer dependencies while pinning local development to 0.84.2
- preserve fail-closed runtime compatibility with an explicit 0.84.1/0.84.2 allowlist
- exercise extension bootstrap against both Pi versions in CI
- document package, standalone binary, and Claude Code protocol compatibility separately

The standalone build remains pinned to Pi 0.84.1 in `config/pi.env`.

## Verification

- `npm run check` with Pi 0.84.1 (14 tests)
- `npm run check` with Pi 0.84.2 (14 tests)
- `actionlint .github/workflows/verify.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility for Pi versions 0.84.1 and 0.84.2.
  - Pi Black now validates supported versions and rejects unsupported or unverified versions.

- **Documentation**
  - Updated installation and compatibility documentation, including standalone binary and Claude Code protocol compatibility details.

- **Tests**
  - Added automated checks for supported Pi versions, expected-version validation, provider registration, and rejection of invalid versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->