### PR TITLE
fix: support Pi versions from 0.84.1 onward

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,6 +26,7 @@ jobs:
           - '0.84.1'
           - '0.84.2'
           - '0.84.3'
+          - '0.84.4'
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Pi Black has three independently versioned compatibility surfaces:
 
 | Component | Compatible version |
 | --- | --- |
-| Pi package | Pi 0.84.1, 0.84.2, and 0.84.3 |
+| Pi package | Pi 0.84.1 or newer |
 | Standalone `pi-black` binary | Based on Pi 0.84.1 |
 | Claude Code protocol | 2.1.224 |
 
-The Pi package fails closed on versions other than 0.84.1, 0.84.2, and 0.84.3. Each new Pi version must be explicitly revalidated and added to the runtime allowlist; the package peer dependencies are `"*"` because Pi supplies its core packages at runtime.
+The Pi package requires Pi 0.84.1 or newer, with no upper version limit. Future Pi releases are trusted until an incompatibility is identified; the package peer dependencies are `"*"` because Pi supplies its core packages at runtime.
 
 ```sh
 pi install git:github.com/paoloanzn/pi-black

--- a/extensions/pi-black.ts
+++ b/extensions/pi-black.ts
@@ -4,13 +4,13 @@ import { wrapAnthropicProvider } from "../src/anthropic-provider.ts";
 import { discoverClaudeCodeIdentity } from "../src/claude-code-protocol.ts";
 import {
 	isSupportedPiVersion,
-	SUPPORTED_PI_VERSIONS,
+	MINIMUM_SUPPORTED_PI_VERSION,
 } from "../src/compatibility.ts";
 
 export default function piBlack(pi: ExtensionAPI): void {
 	if (!isSupportedPiVersion(VERSION)) {
 		throw new Error(
-			`Pi Black supports Pi ${SUPPORTED_PI_VERSIONS.join(", ")}; running Pi is ${VERSION}`,
+			`Pi Black requires Pi ${MINIMUM_SUPPORTED_PI_VERSION} or newer; running Pi is ${VERSION}`,
 		);
 	}
 	const anthropic = builtinProviders().find(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.84.3",
-        "@earendil-works/pi-coding-agent": "0.84.3",
+        "@earendil-works/pi-ai": "0.84.4",
+        "@earendil-works/pi-coding-agent": "0.84.4",
         "@types/node": "24.12.4",
         "typescript": "5.9.3",
         "vitest": "4.1.9"
@@ -514,15 +514,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
-      "integrity": "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -539,18 +539,18 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.3.tgz",
-      "integrity": "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.4.tgz",
+      "integrity": "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-client": "^0.84.3",
-        "@earendil-works/pi-protocol": "^0.84.3",
-        "@earendil-works/pi-tui": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-client": "^0.84.4",
+        "@earendil-works/pi-protocol": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1040,13 +1040,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1057,14 +1057,14 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -1081,20 +1081,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.3"
+        "@earendil-works/pi-protocol": "^0.84.4"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1105,8 +1105,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1114,8 +1114,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2434,9 +2434,9 @@
       }
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
-      "integrity": "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.84.3",
-    "@earendil-works/pi-coding-agent": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.4",
+    "@earendil-works/pi-coding-agent": "0.84.4",
     "@types/node": "24.12.4",
     "typescript": "5.9.3",
     "vitest": "4.1.9"

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -1,9 +1,23 @@
-export const SUPPORTED_PI_VERSIONS = ["0.84.1", "0.84.2", "0.84.3"] as const;
+export const MINIMUM_SUPPORTED_PI_VERSION = "0.84.1";
 
-export type SupportedPiVersion = (typeof SUPPORTED_PI_VERSIONS)[number];
+type StableVersion = readonly [number, number, number];
 
-export function isSupportedPiVersion(
-	version: string,
-): version is SupportedPiVersion {
-	return (SUPPORTED_PI_VERSIONS as readonly string[]).includes(version);
+function parseStableVersion(version: string): StableVersion | undefined {
+	const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(version);
+	if (!match) return undefined;
+
+	const parsed = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+	return parsed.every(Number.isSafeInteger) ? parsed : undefined;
+}
+
+export function isSupportedPiVersion(version: string): boolean {
+	const candidate = parseStableVersion(version);
+	const minimum = parseStableVersion(MINIMUM_SUPPORTED_PI_VERSION);
+	if (!candidate || !minimum) return false;
+
+	for (let index = 0; index < candidate.length; index++) {
+		if (candidate[index] > minimum[index]) return true;
+		if (candidate[index] < minimum[index]) return false;
+	}
+	return true;
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import piBlack from "../extensions/pi-black.ts";
 import {
 	isSupportedPiVersion,
-	SUPPORTED_PI_VERSIONS,
+	MINIMUM_SUPPORTED_PI_VERSION,
 } from "../src/compatibility.ts";
 
 describe("Pi Black extension", () => {
@@ -23,8 +23,20 @@ describe("Pi Black extension", () => {
 		expect(registerProvider.mock.calls[0][0].id).toBe("anthropic");
 	});
 
-	it("fails closed for Pi versions that have not been validated", () => {
-		expect(SUPPORTED_PI_VERSIONS).toEqual(["0.84.1", "0.84.2", "0.84.3"]);
-		expect(isSupportedPiVersion("0.84.4")).toBe(false);
+	it("supports the minimum Pi version and newer stable versions", () => {
+		expect(MINIMUM_SUPPORTED_PI_VERSION).toBe("0.84.1");
+		for (const version of ["0.84.1", "0.84.4", "0.85.0", "1.0.0"])
+			expect(isSupportedPiVersion(version)).toBe(true);
+	});
+
+	it("rejects Pi versions below the minimum or with an invalid format", () => {
+		for (const version of [
+			"0.83.999",
+			"0.84.0",
+			"0.84",
+			"0.84.1-beta.1",
+			"invalid",
+		])
+			expect(isSupportedPiVersion(version)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- replace the exact Pi version allowlist with a minimum supported version
- accept stable Pi releases from 0.84.1 onward, with no upper version limit
- update compatibility tests, documentation, development packages, and CI for Pi 0.84.4

## Verification

- Pi 0.84.1: 15 tests passed
- Pi 0.84.2: 15 tests passed
- Pi 0.84.3: 15 tests passed
- Pi 0.84.4: 15 tests passed
- clean `npm ci && npm run check` passed

Closes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Pi Black now supports Pi version 0.84.1 and newer, without an upper version limit.
  * Unsupported or incorrectly formatted Pi versions continue to be rejected.
* **Documentation**
  * Updated the compatibility guidance to reflect the expanded Pi version support.
* **Verification**
  * Compatibility checks now include Pi 0.84.4 and validate newer, older, and malformed version values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->